### PR TITLE
atualização de dependencias e ajuste no script de start

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Para criar os scripts, vá no arquivo `package.json` e insira o seguinte código
 ```json
 {
   "scripts": {
-    "start": "webpack-dev-server --progress --inline --hot --port 8080",
+    "start": "webpack serve --progress --inline --hot --port 8080",
     "build": "cross-env NODE_ENV=production babel src --out-dir dist"
   }
 }

--- a/exemplo/package.json
+++ b/exemplo/package.json
@@ -10,22 +10,22 @@
     "README.md"
   ],
   "devDependencies": {
-    "prop-types": "^15.7.2",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.7",
     "@babel/preset-react": "^7.8.3",
-    "babel-loader": "^8.0.6",
+    "babel-loader": "^8.2.2",
     "cross-env": "^7.0.2",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "^3.10.3"
+    "html-webpack-plugin": "^5.3.1",
+    "prop-types": "^15.7.2",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
+    "webpack": "^5.26.0",
+    "webpack-cli": "^4.5.0",
+    "webpack-dev-server": "^3.11.2"
   },
   "scripts": {
-    "start": "webpack-dev-server --progress --inline --hot --port 8080",
+    "start": "webpack serve --progress --inline --hot --port 8080",
     "build": "cross-env NODE_ENV=production babel src --out-dir dist"
   }
 }


### PR DESCRIPTION
Ao se criar um novo projeto com base no tutorial, quando se roda o `yarn add -D webpack-cli` a versão mais nova é a `4.5.0`. 

A partir das versões `4.x` o comando `webpack-dev-server` quebra, e de acordo com [essa resposta de uma issue](https://github.com/webpack/webpack-dev-server/issues/2029#issuecomment-707034614) a solução é mudar para `webpack serve`.